### PR TITLE
docs: Rectify typographical inaccuracies 

### DIFF
--- a/hangman/src/main.leo
+++ b/hangman/src/main.leo
@@ -24,7 +24,7 @@ circuit Point {
 
     //! 111. For example, can you instantiate a point p, and then negate it.
     //! You will need to use field elements, such as 0field, 1field, 2field, ...:
-    //! When defining a struct such as point, we do `Point{x_1: something, x_2: something}'
+    //! When defining a struct such as a point, we do `Point{x_1: something, x_2: something}'
     // let p = Point{x: 1, y: 1};
     // let minus_p = p.ec_negate();
     // console.log("the coordinates are {} and {}", minus_p.x, minus_p.y);

--- a/hangman/src/question_1.leo
+++ b/hangman/src/question_1.leo
@@ -26,7 +26,7 @@ circuit Point {
 function main() {
     //! 111. For example, can you instantiate a point p, and then negate it.
     //! You will need to use field elements, such as 0field, 1field, 2field, ...:
-    //! When defining a struct such as point, we do `Point{x_1: something, x_2: something}'
+    //! When defining a struct such as a point, we do `Point{x_1: something, x_2: something}'
     let p = Point{x: 1, y: 1};
     let minus_p = p.ec_negate();
     console.log("the coordinates are {} and {}", minus_p.x, minus_p.y);

--- a/hangman/src/question_2.leo
+++ b/hangman/src/question_2.leo
@@ -24,7 +24,7 @@ circuit Point {
 
     //! 111. For example, can you instantiate a point p, and then negate it.
     //! You will need to use field elements, such as 0field, 1field, 2field, ...:
-    //! When defining a struct such as point, we do `Point{x_1: something, x_2: something}'
+    //! When defining a struct such as a point, we do `Point{x_1: something, x_2: something}'
     // let p = Point{x: 1, y: 1};
     // let minus_p = p.ec_negate();
     // console.log("the coordinates are {} and {}", minus_p.x, minus_p.y);

--- a/hangman/src/question_4.leo
+++ b/hangman/src/question_4.leo
@@ -88,7 +88,7 @@ circuit Hangman {
         // The `zero` group element for Edwards BLS12
         const digest: Point = Point { x: 0field, y: 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177field };
 
-        // x and y coordiantes corresponding to the `one` group element.
+        // x and y coordinates corresponding to the `one` group element.
         const x: field = 7810607721416582242904415504650443951498042435501746664987470571546413371306field;
         const y: field = 1867362672570137759132108893390349941423731440336755218616442213142473202417field;
 

--- a/hangman/src/question_5.leo
+++ b/hangman/src/question_5.leo
@@ -88,7 +88,7 @@ circuit Hangman {
         // The `zero` group element for Edwards BLS12
         const digest: Point = Point { x: 0field, y: 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177field };
 
-        // x and y coordiantes corresponding to the `one` group element.
+        // x and y coordinates corresponding to the `one` group element.
         const x: field = 7810607721416582242904415504650443951498042435501746664987470571546413371306field;
         const y: field = 1867362672570137759132108893390349941423731440336755218616442213142473202417field;
 

--- a/hangman/src/question_6.leo
+++ b/hangman/src/question_6.leo
@@ -88,7 +88,7 @@ circuit Hangman {
         // The `zero` group element for Edwards BLS12
         const digest: Point = Point { x: 0field, y: 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177field };
 
-        // x and y coordiantes corresponding to the `one` group element.
+        // x and y coordinates corresponding to the `one` group element.
         const x: field = 7810607721416582242904415504650443951498042435501746664987470571546413371306field;
         const y: field = 1867362672570137759132108893390349941423731440336755218616442213142473202417field;
 

--- a/hangman/src/workshop_exercise.leo
+++ b/hangman/src/workshop_exercise.leo
@@ -91,7 +91,7 @@ circuit Hangman {
         // The `zero` group element for Edwards BLS12
         const digest: Point = Point { x: 0field, y: 258664426012969094010652733694893533536393512754914660539884262666720468348340822774968888139573360124440321458177field };
 
-        // x and y coordiantes corresponding to the `one` group element.
+        // x and y coordinates corresponding to the `one` group element.
         const x: field = 7810607721416582242904415504650443951498042435501746664987470571546413371306field;
         const y: field = 1867362672570137759132108893390349941423731440336755218616442213142473202417field;
 


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.